### PR TITLE
Unlock Bug Fix

### DIFF
--- a/__tests__/utils/storageHelpers.test.ts
+++ b/__tests__/utils/storageHelpers.test.ts
@@ -2,7 +2,7 @@ import {
 	getItemForKey,
 	removeItemForKey,
 	StorageKeys,
-	storeData,
+	setItemForKey,
 } from '@/app/utils/storageHelpers';
 import AsyncStorage from '@react-native-async-storage/async-storage/jest/async-storage-mock';
 
@@ -14,7 +14,7 @@ describe('Storage Helpers', () => {
 	it('should store item in storage', async () => {
 		expect(await getItemForKey(StorageKeys.HAS_LAUNCHED)).toBeUndefined();
 
-		await storeData(StorageKeys.HAS_LAUNCHED, 'true');
+		await setItemForKey(StorageKeys.HAS_LAUNCHED, 'true');
 
 		expect(await getItemForKey(StorageKeys.HAS_LAUNCHED)).toBe('true');
 	});
@@ -30,7 +30,7 @@ describe('Storage Helpers', () => {
 	it('should get existing item from storage and return stored value', async () => {
 		const expectedHasLaunched = 'true';
 
-		await storeData(StorageKeys.HAS_LAUNCHED, expectedHasLaunched);
+		await setItemForKey(StorageKeys.HAS_LAUNCHED, expectedHasLaunched);
 		const hasLaunched = await getItemForKey(StorageKeys.HAS_LAUNCHED);
 
 		expect(hasLaunched).toBeDefined();

--- a/app/(root)/(tabs)/steps.tsx
+++ b/app/(root)/(tabs)/steps.tsx
@@ -7,7 +7,7 @@ import { StatusBar } from 'expo-status-bar';
 import {
 	getItemForKey,
 	StorageKeys,
-	storeData,
+	setItemForKey,
 } from '@/app/utils/storageHelpers';
 import {
 	widthPercentageToDP as wp,
@@ -37,7 +37,7 @@ export default function StepsHomeScreen() {
 				setStepGoal(JSON.parse(data));
 			} else {
 				console.log('Step goal not found in storage...');
-				storeData(StorageKeys.STEP_GOAL, '10000');
+				setItemForKey(StorageKeys.STEP_GOAL, '10000');
 			}
 		};
 
@@ -50,8 +50,8 @@ export default function StepsHomeScreen() {
 		} else {
 			setGoalReached(false);
 		}
-		storeData(StorageKeys.STEP_GOAL, JSON.stringify(stepGoal)).catch((error) =>
-			console.log(error)
+		setItemForKey(StorageKeys.STEP_GOAL, JSON.stringify(stepGoal)).catch(
+			(error) => console.log(error)
 		);
 	}, [todaySteps, stepGoal]);
 

--- a/app/utils/storageHelpers.ts
+++ b/app/utils/storageHelpers.ts
@@ -4,9 +4,10 @@ export enum StorageKeys {
 	HAS_LAUNCHED = 'HAS_LAUNCHED',
 	POKEMONS = 'POKEMONS',
 	STEP_GOAL = 'STEP_GOAL',
+	LOCKED_POKEMON_IDS = 'LOCKED_POKEMON_IDS',
 }
 
-export const storeData = async (key: string, value: string) => {
+export const setItemForKey = async (key: string, value: string) => {
 	try {
 		await AsyncStorage.setItem(key, JSON.stringify(value));
 	} catch (error) {

--- a/components/ProgressRing.tsx
+++ b/components/ProgressRing.tsx
@@ -38,7 +38,7 @@ const ProgressRing = ({ progress = 0.0, goalReached }: ProgressRingProps) => {
 	}, [progress]);
 
 	const handlePress = () => {
-		const randomId = Math.ceil(Math.random() * 151);
+		const randomId = Math.ceil(Math.random() * state.lockedPokemonIds.size);
 
 		dispatch({
 			type: 'unlock_pokemon',


### PR DESCRIPTION
Add set of locked Pokemon IDs and select random Pokemon from the set whenever user unlocks a new Pokemon. This ensure no duplicates happen.