### PR TITLE
Disable Pokeball After Unlocking Pokemon

### DIFF
--- a/__tests__/components/ProgressRing.test.tsx
+++ b/__tests__/components/ProgressRing.test.tsx
@@ -9,7 +9,7 @@ jest.mock('@rneui/themed', () => ({
 
 describe('<ProgressRing />', () => {
 	it('should render the progress ring without Pokéball button when goal is not reached', () => {
-		const screen = render(<ProgressRing progress={0.5} goalReached={false} />);
+		const screen = render(<ProgressRing progress={0.5} goalMet={false} />);
 
 		const pokeball = screen.queryByRole('button');
 
@@ -17,7 +17,7 @@ describe('<ProgressRing />', () => {
 	});
 
 	it('should render the progress ring with Pokéball button when goal is reached', () => {
-		const screen = render(<ProgressRing progress={1} goalReached={true} />);
+		const screen = render(<ProgressRing progress={1} goalMet={true} />);
 
 		const pokeball = screen.getByTestId('pokeball-button');
 
@@ -26,7 +26,7 @@ describe('<ProgressRing />', () => {
 	});
 
 	it('should disable the Pokéball button and display overlay when it is pressed once', async () => {
-		const screen = render(<ProgressRing progress={1} goalReached={true} />);
+		const screen = render(<ProgressRing progress={1} goalMet={true} />);
 
 		const pokeball = screen.getByTestId('pokeball-button');
 		await userEvent.press(pokeball);

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
 	"expo": {
 		"name": "Pokesteps",
 		"slug": "Pokesteps",
-		"version": "1.0.1",
+		"version": "1.0.2",
 		"orientation": "portrait",
 		"icon": "assets/images/appstore/appstore.png",
 		"scheme": "myapp",

--- a/app/(root)/(tabs)/_layout.tsx
+++ b/app/(root)/(tabs)/_layout.tsx
@@ -1,3 +1,4 @@
+import { APP_COLOR } from '@/app/utils/constants';
 import { Tabs } from 'expo-router';
 import { View, Image, ImageSourcePropType } from 'react-native';
 import {
@@ -41,7 +42,7 @@ function TabLayout() {
 			screenOptions={{
 				tabBarShowLabel: false,
 				tabBarStyle: {
-					backgroundColor: '#FFCB05',
+					backgroundColor: APP_COLOR.yellow,
 					borderRadius: 50,
 					paddingBottom: 0,
 					marginBottom: hp('3%'),

--- a/app/(root)/(tabs)/steps.tsx
+++ b/app/(root)/(tabs)/steps.tsx
@@ -1,4 +1,11 @@
-import { Text, TouchableOpacity, View, Image, Alert } from 'react-native';
+import {
+	Text,
+	TouchableOpacity,
+	View,
+	Image,
+	Alert,
+	Button,
+} from 'react-native';
 import React, { useEffect, useState } from 'react';
 import useHealthData from '@/hooks/useHealthData';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -8,12 +15,14 @@ import {
 	getItemForKey,
 	StorageKeys,
 	setItemForKey,
+	removeItemForKey,
 } from '@/app/utils/storageHelpers';
 import {
 	widthPercentageToDP as wp,
 	heightPercentageToDP as hp,
 } from 'react-native-responsive-screen';
 import EditStepGoal from '@/components/EditStepGoal';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const textSizes = {
 	xl: hp('1.5%'),
@@ -25,7 +34,8 @@ const textSizes = {
 export default function StepsHomeScreen() {
 	const { todaySteps, yesterdaySteps } = useHealthData();
 	const [stepGoal, setStepGoal] = useState(3000);
-	const [goalReached, setGoalReached] = useState(false);
+	const [goalMet, setGoalMet] = useState(false);
+	const [disabled, setDisabled] = useState(false);
 	const [visible, setVisible] = useState(false);
 	const progress = todaySteps / stepGoal;
 
@@ -46,9 +56,9 @@ export default function StepsHomeScreen() {
 
 	useEffect(() => {
 		if (todaySteps >= stepGoal) {
-			setGoalReached(true);
+			setGoalMet(true);
 		} else {
-			setGoalReached(false);
+			setGoalMet(false);
 		}
 		setItemForKey(StorageKeys.STEP_GOAL, JSON.stringify(stepGoal)).catch(
 			(error) => console.log(error)
@@ -73,7 +83,7 @@ export default function StepsHomeScreen() {
 				currentStepGoal={stepGoal}
 				setStepGoal={setStepGoal}
 			/>
-			<ProgressRing progress={progress} goalReached={goalReached} />
+			<ProgressRing progress={progress} goalMet={goalMet} />
 			<View className='flex justify-center items-center font-JetBrainsMono'>
 				<Text
 					className='font-JetBrainsMono'

--- a/app/(root)/(tabs)/steps.tsx
+++ b/app/(root)/(tabs)/steps.tsx
@@ -1,11 +1,4 @@
-import {
-	Text,
-	TouchableOpacity,
-	View,
-	Image,
-	Alert,
-	Button,
-} from 'react-native';
+import { Text, TouchableOpacity, View, Image } from 'react-native';
 import React, { useEffect, useState } from 'react';
 import useHealthData from '@/hooks/useHealthData';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -15,14 +8,12 @@ import {
 	getItemForKey,
 	StorageKeys,
 	setItemForKey,
-	removeItemForKey,
 } from '@/app/utils/storageHelpers';
 import {
 	widthPercentageToDP as wp,
 	heightPercentageToDP as hp,
 } from 'react-native-responsive-screen';
 import EditStepGoal from '@/components/EditStepGoal';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const textSizes = {
 	xl: hp('1.5%'),
@@ -35,7 +26,6 @@ export default function StepsHomeScreen() {
 	const { todaySteps, yesterdaySteps } = useHealthData();
 	const [stepGoal, setStepGoal] = useState(3000);
 	const [goalMet, setGoalMet] = useState(false);
-	const [disabled, setDisabled] = useState(false);
 	const [visible, setVisible] = useState(false);
 	const progress = todaySteps / stepGoal;
 

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -56,3 +56,8 @@ export const GET_POKEMONS_RESPONSE = {
 	types: ['grass', 'poison'],
 	unlocked: false,
 };
+
+export const APP_COLOR: { [key: string]: string } = {
+	blue: '#3C5AA6',
+	yellow: '#FFCB05',
+};

--- a/app/utils/storageHelpers.ts
+++ b/app/utils/storageHelpers.ts
@@ -3,9 +3,15 @@ import { Pokemon } from '../common/interface/pokemon.mixin';
 
 export enum StorageKeys {
 	HAS_LAUNCHED = 'HAS_LAUNCHED',
+	HAS_UNLOCKED = 'HAS_UNLOCKED',
 	POKEMONS = 'POKEMONS',
 	STEP_GOAL = 'STEP_GOAL',
 	LOCKED_POKEMON_IDS = 'LOCKED_POKEMON_IDS',
+}
+
+interface LoadDataResponse {
+	pokemons: Pokemon[];
+	lockedIds: Set<number>;
 }
 
 export const setItemForKey = async (key: string, value: string) => {
@@ -45,15 +51,14 @@ export const initializeData = async (
 			StorageKeys.LOCKED_POKEMON_IDS,
 			[...lockedPokemonIds].join(',')
 		);
-		await AsyncStorage.setItem(StorageKeys.HAS_LAUNCHED, 'true');
+		await setItemForKey(StorageKeys.HAS_LAUNCHED, 'true');
+		await setItemForKey(StorageKeys.HAS_UNLOCKED, 'false');
 	} catch (error) {
 		throw error;
 	}
 };
 
-export const loadData = async (): Promise<
-	{ pokemons: Pokemon[]; lockedIds: Set<number> } | undefined
-> => {
+export const loadData = async (): Promise<LoadDataResponse | undefined> => {
 	try {
 		const pokemons = await getItemForKey(StorageKeys.POKEMONS);
 		const lockedPokemonIds = await getItemForKey(

--- a/components/EditStepGoal.tsx
+++ b/components/EditStepGoal.tsx
@@ -9,6 +9,7 @@ import {
 import Modal from 'react-native-modal';
 import { widthPercentageToDP as wp } from 'react-native-responsive-screen';
 import ErrorMessage from './ErrorMessage';
+import { APP_COLOR } from '@/app/utils/constants';
 
 interface EditStepGoalsProps {
 	currentStepGoal: number;
@@ -85,7 +86,10 @@ const EditStepGoal = ({
 						</Text>
 					</TouchableOpacity>
 					<Pressable
-						className='w-2/5 rounded-xl bg-[#FFCB05] px-3 py-2 m-1'
+						className='w-2/5 rounded-xl px-3 py-2 m-1'
+						style={{
+							backgroundColor: APP_COLOR.yellow,
+						}}
 						onPress={onSave}
 					>
 						<Text className='text-center font-JetBrainsMonoSemiBold'>Save</Text>

--- a/components/PokemonUnlocked.tsx
+++ b/components/PokemonUnlocked.tsx
@@ -7,6 +7,7 @@ import {
 	widthPercentageToDP as wp,
 	heightPercentageToDP as hp,
 } from 'react-native-responsive-screen';
+import { APP_COLOR } from '@/app/utils/constants';
 
 interface PokemonUnlockedProps {
 	visible: boolean;
@@ -72,7 +73,10 @@ const PokemonUnlocked = ({ visible, setVisible }: PokemonUnlockedProps) => {
 						router.replace('/(root)/(tabs)/pokedex');
 						setVisible(false);
 					}}
-					className='bg-[#FFCB05] p-2 w-auto h-auto text-center justify-center rounded-lg'
+					className='p-2 w-auto h-auto text-center justify-center rounded-lg'
+					style={{
+						backgroundColor: APP_COLOR.yellow,
+					}}
 				>
 					<Text
 						className='text-black font-JetBrainsMonoBold uppercase'


### PR DESCRIPTION
This PR contains fix that prevents users from abusing the unlocking functionality by closing and reopening the app again after goal is met.